### PR TITLE
added ValueTransformerDistributeIri

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,48 @@ Options:
 * `"searchRegex"`: The regex to search for.
 * `"replacementString"`: The string to replace.
 
+#### Distribute IRI Value Transformer
+
+A value transformer that that replaces (parts of) IRIs, deterministically distributing the replacements over a list of multiple destination IRI based on a matched number.
+This is fully compatible with rdf-dataset-fragmenter QuadTransformerDistributeIri which produces the same deterministic replacements.
+
+```json
+{
+  "valueTransformers": [
+    {
+      "@type": "ValueTransformerDistributeIri",
+      "searchRegex": "^http://www.ldbc.eu",
+      "replacementStrings": [
+        "http://localhost:3000/www.ldbc.eu",
+        "http://localhost:3030/www.ldbc.eu",
+        "http://localhost:3060/www.ldbc.eu"
+      ]
+    }
+  ]
+}
+```
+
+This requires at least one group-based replacement, of which the first group must match a number.
+
+The matched number is used to choose one of the `replacementStrings` in a deterministic way: `replacementStrings[number % replacementStrings.length]`
+
+```json
+{
+  "@type": "ValueTransformerDistributeIri",
+  "searchRegex": "^http://www.ldbc.eu/data/pers([0-9]*)$",
+  "replacementStrings": [
+    "https://one.example.com/users$1/profile/card#me",
+    "https://two.example.com/users$1/profile/card#me",
+    "https://three.example.com/users$1/profile/card#me",
+    "https://four.example.com/users$1/profile/card#me"
+  ]
+}
+```
+
+Options:
+* `"searchRegex"`: The regex to search for. A group is identified via `()` in the search regex. There must be at least one group. The first group must match a number.
+* `"replacementStrings"`: A list of string to use as replacements. A reference to the matched group can be made via `$...`.
+
 #### Replace IRI Value Transformer
 
 A value transformer that pads strings until a given length.

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ export * from './lib/substitution/SubstitutionProviderStatic';
 export * from './lib/substitution/SubstitutionProviderUnion';
 export * from './lib/valuetransformer/IValueTransformer';
 export * from './lib/valuetransformer/ValueTransformerPad';
+export * from './lib/valuetransformer/ValueTransformerDistributeIri';
 export * from './lib/valuetransformer/ValueTransformerReplaceIri';
 export * from './lib/variable/IVariableTemplate';
 export * from './lib/variable/VariableTemplateAdapter';

--- a/lib/valuetransformer/ValueTransformerDistributeIri.ts
+++ b/lib/valuetransformer/ValueTransformerDistributeIri.ts
@@ -1,0 +1,46 @@
+import type * as RDF from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import type { IValueTransformer } from './IValueTransformer';
+
+const DF = new DataFactory();
+
+/**
+ * A value transformer that that replaces (parts of) IRIs,
+ * deterministically distributing the replacements over a list of multiple destination IRI, based on a matched number.
+ *
+ * This requires at least one group-based replacement, of which the first group must match a number.
+ *
+ * The matched number is used to choose one of the `replacementStrings` in a deterministic way:
+ *    replacementStrings[number % replacementStrings.length]
+ * This is the same as QuadTransformerDistributeIri and is thus compatible with it.
+ */
+export class ValueTransformerDistributeIri implements IValueTransformer {
+  private readonly search: RegExp;
+  private readonly replacements: string[];
+
+  public constructor(searchRegex: string, replacementStrings: string[]) {
+    this.search = new RegExp(searchRegex, 'u');
+    this.replacements = replacementStrings;
+  }
+
+  public transform(term: RDF.Term): RDF.Term {
+    if (term.termType === 'NamedNode') {
+      const match = this.search.exec(term.value);
+      if (match) {
+        if (match.length < 2) {
+          throw new Error(`ValueTransformerDistributeIri error: The "searchRegex" did not contain any groups. 
+              QuadTransformerDistributeIri requires at least one group-based replacement, 
+              of which the first group must match a number.`);
+        }
+        const nr = Number.parseInt(match[1], 10);
+        if (Number.isNaN(nr)) {
+          throw new Error(`ValueTransformerDistributeIri error: The first capture group in "searchRegex"
+               must always match a number, but it matched "${match[1]}" instead.`);
+        }
+        const newValue = term.value.replace(this.search, this.replacements[nr % this.replacements.length]);
+        return DF.namedNode(newValue);
+      }
+    }
+    return term;
+  }
+}

--- a/test/valuetransformer/ValueTransformerDistributeIri-test.ts
+++ b/test/valuetransformer/ValueTransformerDistributeIri-test.ts
@@ -1,0 +1,67 @@
+import { DataFactory } from 'rdf-data-factory';
+import { ValueTransformerDistributeIri } from '../../lib/valuetransformer/ValueTransformerDistributeIri';
+
+const DF = new DataFactory();
+
+describe('ValueTransformerDistributeIri', () => {
+  let transformer: ValueTransformerDistributeIri;
+
+  beforeEach(() => {
+    transformer = new ValueTransformerDistributeIri(
+      '^http://www.ldbc.eu/data/pers([0-9]*)$',
+      [ 'http://server1.ldbc.eu/pods/$1/profile/card#me', 'http://server2.ldbc.eu/pods/$1/profile/card#me' ],
+    );
+  });
+
+  describe('transform', () => {
+    it('should modify applicable values', async() => {
+      expect(transformer.transform(
+        DF.namedNode('http://www.ldbc.eu/data/pers0494'),
+      )).toEqual(
+        DF.namedNode('http://server1.ldbc.eu/pods/0494/profile/card#me'),
+      );
+
+      expect(transformer.transform(
+        DF.namedNode('http://www.ldbc.eu/data/pers0495'),
+      )).toEqual(
+        DF.namedNode('http://server2.ldbc.eu/pods/0495/profile/card#me'),
+      );
+    });
+
+    it('should not modify non-applicable terms', async() => {
+      expect(transformer.transform(
+        DF.literal('http://www.ldbc.eu/data/pers0495'),
+      )).toEqual(
+        DF.literal('http://www.ldbc.eu/data/pers0495'),
+      );
+
+      expect(transformer.transform(
+        DF.namedNode('http://example.com/data/pers0495'),
+      )).toEqual(
+        DF.namedNode('http://example.com/data/pers0495'),
+      );
+    });
+
+    it('should throw error for first regex group not capturing number', async() => {
+      const badTransformer = new ValueTransformerDistributeIri(
+        '^http://www.ldbc.eu/data/(pers[0-9]*)$',
+        [ 'http://server1.ldbc.eu/pods/$1/profile/card#me', 'http://server2.ldbc.eu/pods/$1/profile/card#me' ],
+      );
+
+      expect(() => badTransformer.transform(
+        DF.namedNode('http://www.ldbc.eu/data/pers0495'),
+      )).toThrow();
+    });
+
+    it('should throw error when no regex groups', async() => {
+      const badTransformer = new ValueTransformerDistributeIri(
+        '^http://www.ldbc.eu/data/pers[0-9]*$',
+        [ 'http://server1.ldbc.eu/pods/$1/profile/card#me', 'http://server2.ldbc.eu/pods/$1/profile/card#me' ],
+      );
+
+      expect(() => badTransformer.transform(
+        DF.namedNode('http://www.ldbc.eu/data/pers0495'),
+      )).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Added a value transformer that that replaces (parts of) IRIs, deterministically distributing the replacements over a list of multiple destination IRI based on a matched number.

This is fully compatible with https://github.com/SolidBench/rdf-dataset-fragmenter.js/pull/21  which produces the same deterministic replacements.